### PR TITLE
Add configuration for file extensions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,6 @@
         "@typescript-eslint"
     ],
     "rules": {
-        "@typescript-eslint/class-name-casing": "warn",
         "@typescript-eslint/semi": "warn",
         "curly": "warn",
         "eqeqeq": "warn",

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 out
 node_modules
 .vscode-test/
+.history/
 *.vsix
+*.arb
+l10n/app_zh.json

--- a/demo/.vscode/settings.json
+++ b/demo/.vscode/settings.json
@@ -5,6 +5,10 @@
     "i18n",
     "locales"
   ],
+  "i18nJsonEditor.supportedExtensions": [
+    "arb",
+    "json"
+  ],
   "i18nJsonEditor.workspaceFolders": [
     { "name": "Common", "path": "./i18n" },
     { "name": "Portal", "path": "./portal/locales" }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "description": "Easily edit your i18n json files",
     "icon": "media/logo.png",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "engines": {
         "vscode": "^1.30.0"
     },
@@ -76,6 +76,14 @@
                     ],
                     "type": "array",
                     "description": "An array of folder names that's used to open the extension through the right click (restart required after changing the value)"
+                },
+                "i18nJsonEditor.supportedExtensions": {
+                    "default": [
+                        "arb",
+                        "json"
+                    ],
+                    "type": "array",
+                    "description": "An array of file extension to check when loading the editor. if no file exists then the first one is used by default (restart required after changing the value)"
                 },
                 "i18nJsonEditor.translationService": {
                     "type": "string",

--- a/src/i18n-json-editor/ije-configuration.ts
+++ b/src/i18n-json-editor/ije-configuration.ts
@@ -58,18 +58,4 @@ export class IJEConfiguration {
 
         return _folders !== undefined ? _folders : [];
     }
-    static get WORKSPACE_EXTENSIONS(): IJEFolder[] {
-        const extensions = vscode.workspace.getConfiguration().get<IJEFolder[]>('i18nJsonEditor.workspaceExtensions');
-        let workspaceExtension: vscode.WorkspaceFolder | undefined = vscode.workspace.workspaceExtensions[0];
-
-        const _folders: IJEFolder[] = [];
-        extensions.forEach(d => {
-            var path = vscode.Uri.file(_path.join(workspaceExtension.uri.fsPath, d.path)).fsPath;
-            if (fs.existsSync(path)) {
-                _folders.push({ name: d.name, path: path });
-            }
-        });
-
-        return _folders !== undefined ? _folders : [];
-    }
 }

--- a/src/i18n-json-editor/ije-configuration.ts
+++ b/src/i18n-json-editor/ije-configuration.ts
@@ -28,7 +28,11 @@ export class IJEConfiguration {
 
     static get SUPPORTED_FOLDERS(): string[] {
         const value = vscode.workspace.getConfiguration().get<string[]>('i18nJsonEditor.supportedFolders');
-        return value !== undefined ? value : ['i18n'];
+        return value !== undefined ? value : ['i18n','l10n'];
+    }
+    static get SUPPORTED_EXTENSIONS(): string[] {
+        const value = vscode.workspace.getConfiguration().get<string[]>('i18nJsonEditor.supportedExtensions');
+        return value !== undefined ? value : ['arb','json'];
     }
     static get TRANSLATION_SERVICE(): TranslationServiceEnum {
         const value = vscode.workspace.getConfiguration().get<TranslationServiceEnum>('i18nJsonEditor.translationService');
@@ -47,6 +51,20 @@ export class IJEConfiguration {
         const _folders: IJEFolder[] = [];
         folders.forEach(d => {
             var path = vscode.Uri.file(_path.join(workspaceFolder.uri.fsPath, d.path)).fsPath;
+            if (fs.existsSync(path)) {
+                _folders.push({ name: d.name, path: path });
+            }
+        });
+
+        return _folders !== undefined ? _folders : [];
+    }
+    static get WORKSPACE_EXTENSIONS(): IJEFolder[] {
+        const extensions = vscode.workspace.getConfiguration().get<IJEFolder[]>('i18nJsonEditor.workspaceExtensions');
+        let workspaceExtension: vscode.WorkspaceFolder | undefined = vscode.workspace.workspaceExtensions[0];
+
+        const _folders: IJEFolder[] = [];
+        extensions.forEach(d => {
+            var path = vscode.Uri.file(_path.join(workspaceExtension.uri.fsPath, d.path)).fsPath;
             if (fs.existsSync(path)) {
                 _folders.push({ name: d.name, path: path });
             }

--- a/src/i18n-json-editor/ije-data.ts
+++ b/src/i18n-json-editor/ije-data.ts
@@ -139,12 +139,22 @@ export class IJEData {
             existingFolders = IJEConfiguration.WORKSPACE_FOLDERS.map(d => d.path);
         }
 
+        let existingExtensions = IJEConfiguration.SUPPORTED_EXTENSIONS;
+
         existingFolders.forEach(d => {
             this._languages.forEach(language => {
                 const json = JSON.stringify({}, null, IJEConfiguration.JSON_SPACE);
-                // TODO added code to check what extension to use
-                const f = vscode.Uri.file(_path.join(d, language + '.json')).fsPath;
-                //if fs.existsSync(f)
+                var f = null;
+                existingExtensions.forEach((ext: string) => {
+                    var s = vscode.Uri.file(_path.join(d, language + '.' + ext)).fsPath;
+                    if (fs.existsSync(s)) {
+                        f = s;
+                        return;
+                    };
+                });
+                if (f === null) {
+                    f = vscode.Uri.file(_path.join(d, language + '.' + existingExtensions[0])).fsPath;
+                }
                 fs.writeFileSync(f, json);
             });
         });
@@ -172,8 +182,17 @@ export class IJEData {
 
                 var json = JSON.stringify(o, null, IJEConfiguration.JSON_SPACE);
                 json = json.replace(/\n/g, IJEConfiguration.LINE_ENDING);
-                // TODO added code to check what extension to use
-                const f = vscode.Uri.file(_path.join(key, language + '.json')).fsPath;
+                var f = null;
+                existingExtensions.forEach((ext: string) => {
+                    var s = vscode.Uri.file(_path.join(key, language + '.' + ext)).fsPath;
+                    if (fs.existsSync(s)) {
+                        f = s;
+                        return;
+                    };
+                });
+                if (f === null) {
+                    f = vscode.Uri.file(_path.join(key, language + '.' + existingExtensions[0])).fsPath;
+                }
                 fs.writeFileSync(f, json);
             });
         });

--- a/src/i18n-json-editor/ije-data.ts
+++ b/src/i18n-json-editor/ije-data.ts
@@ -138,10 +138,13 @@ export class IJEData {
         } else {
             existingFolders = IJEConfiguration.WORKSPACE_FOLDERS.map(d => d.path);
         }
+
         existingFolders.forEach(d => {
             this._languages.forEach(language => {
                 const json = JSON.stringify({}, null, IJEConfiguration.JSON_SPACE);
+                // TODO added code to check what extension to use
                 const f = vscode.Uri.file(_path.join(d, language + '.json')).fsPath;
+                //if fs.existsSync(f)
                 fs.writeFileSync(f, json);
             });
         });
@@ -169,6 +172,7 @@ export class IJEData {
 
                 var json = JSON.stringify(o, null, IJEConfiguration.JSON_SPACE);
                 json = json.replace(/\n/g, IJEConfiguration.LINE_ENDING);
+                // TODO added code to check what extension to use
                 const f = vscode.Uri.file(_path.join(key, language + '.json')).fsPath;
                 fs.writeFileSync(f, json);
             });
@@ -270,10 +274,16 @@ export class IJEData {
     private _loadFolder(folderPath: string) {
         const files = fs.readdirSync(folderPath);
 
+        let existingExtensions = IJEConfiguration.SUPPORTED_EXTENSIONS;
+
+        existingExtensions = existingExtensions;
+
         const translate: any = {};
         const keys: string[] = [];
-        files
-            .filter(f => f.endsWith('.json'))
+
+        existingExtensions.forEach((ext: string) => {
+            files
+            .filter(f => f.endsWith("." + ext))
             .forEach((file: string) => {
                 var language = file.split('.')[0];
                 if (this._languages.indexOf(language) === -1) {
@@ -297,6 +307,8 @@ export class IJEData {
                     translate[language] = {};
                 }
             });
+
+        });
 
         keys.forEach((key: string) => {
             const languages: any = {};


### PR DESCRIPTION
These changes will allow you to configure what files extensions can be used via i18nJsonEditor.supportedExtensions the default values are {'arb','json'}

I hope you don't mind me making these changes. I have a few more that I will do soon.